### PR TITLE
feature: require github pages workflow best practices

### DIFF
--- a/packages/plugin-github-actions/src/index.ts
+++ b/packages/plugin-github-actions/src/index.ts
@@ -3,6 +3,7 @@ import * as parserYAML from 'yaml-eslint-parser'
 import * as actionVersions from './rules/action-versions.ts'
 import * as ciVersions from './rules/ci-versions.ts'
 import * as failFast from './rules/fail-fast.ts'
+import * as githubPages from './rules/github-pages.ts'
 import * as githubToken from './rules/github-token.ts'
 import * as matrix from './rules/matrix.ts'
 import * as maxParallel from './rules/max-parallel.ts'
@@ -27,6 +28,7 @@ const plugin = {
     'action-versions': actionVersions,
     'ci-versions': ciVersions,
     'fail-fast': failFast,
+    'github-pages': githubPages,
     'github-token': githubToken,
     matrix: matrix,
     'max-parallel': maxParallel,
@@ -57,6 +59,7 @@ const recommended: Linter.Config[] = [
       'github-actions/action-versions': 'error',
       'github-actions/ci-versions': 'error',
       'github-actions/fail-fast': 'error',
+      'github-actions/github-pages': 'error',
       'github-actions/github-token': 'error',
       'github-actions/matrix': 'off',
       'github-actions/max-parallel': 'error',

--- a/packages/plugin-github-actions/src/rules/github-pages.ts
+++ b/packages/plugin-github-actions/src/rules/github-pages.ts
@@ -1,0 +1,117 @@
+import type { Rule } from 'eslint'
+import type { AST } from 'yaml-eslint-parser'
+import { getSourceCode } from 'eslint-compat-utils'
+
+export const meta: Rule.RuleMetaData = {
+  docs: {
+    description: 'Require GitHub Pages deployment best practices',
+  },
+
+  messages: {
+    missingGithubPagesConcurrency: 'GitHub Pages deployment requires concurrency group pages with cancel-in-progress false',
+    missingGithubPagesPermissions: 'GitHub Pages deployment requires contents read, pages write, and id-token write permissions',
+  },
+
+  type: 'problem',
+} as const
+
+const isCiWorkflow = (fileName: string): boolean => {
+  return fileName.endsWith('/ci.yml') || fileName.endsWith('/ci.yaml') || fileName.endsWith('\\ci.yml') || fileName.endsWith('\\ci.yaml')
+}
+
+type YamlValue = AST.YAMLContent | AST.YAMLWithMeta | null | undefined
+
+const isYamlScalarString = (node: YamlValue, value: string): boolean => {
+  return node?.type === 'YAMLScalar' && node.value === value
+}
+
+const isYamlScalarBoolean = (node: YamlValue, value: boolean): boolean => {
+  return node?.type === 'YAMLScalar' && node.value === value
+}
+
+const isDeployPagesAction = (node: YamlValue): boolean => {
+  return node?.type === 'YAMLScalar' && typeof node.value === 'string' && node.value.startsWith('actions/deploy-pages@')
+}
+
+const isTopLevelPair = (node: AST.YAMLPair): boolean => {
+  return node.parent?.parent?.type === 'YAMLDocument'
+}
+
+const getMappingValue = (mapping: AST.YAMLMapping, key: string): YamlValue => {
+  for (const pair of mapping.pairs) {
+    if (pair.key?.type === 'YAMLScalar' && pair.key.value === key) {
+      return pair.value
+    }
+  }
+  return null
+}
+
+const hasGithubPagesPermissions = (mapping: AST.YAMLMapping | undefined): boolean => {
+  if (!mapping) {
+    return false
+  }
+  return (
+    isYamlScalarString(getMappingValue(mapping, 'contents'), 'read') &&
+    isYamlScalarString(getMappingValue(mapping, 'pages'), 'write') &&
+    isYamlScalarString(getMappingValue(mapping, 'id-token'), 'write')
+  )
+}
+
+const hasGithubPagesConcurrency = (mapping: AST.YAMLMapping | undefined): boolean => {
+  if (!mapping) {
+    return false
+  }
+  return isYamlScalarString(getMappingValue(mapping, 'group'), 'pages') && isYamlScalarBoolean(getMappingValue(mapping, 'cancel-in-progress'), false)
+}
+
+export const create = (context: Rule.RuleContext): Record<string, (node: AST.YAMLPair) => void> => {
+  const sourceCode = getSourceCode(context)
+  if (!sourceCode.parserServices?.isYAML || !isCiWorkflow(context.filename)) {
+    return {}
+  }
+
+  let deployPagesNode: AST.YAMLPair | undefined
+  let permissions: AST.YAMLMapping | undefined
+  let concurrency: AST.YAMLMapping | undefined
+
+  return {
+    'Program:exit'(): void {
+      if (!deployPagesNode) {
+        return
+      }
+      if (!hasGithubPagesPermissions(permissions)) {
+        context.report({
+          messageId: 'missingGithubPagesPermissions',
+          node: deployPagesNode,
+        })
+      }
+      if (!hasGithubPagesConcurrency(concurrency)) {
+        context.report({
+          messageId: 'missingGithubPagesConcurrency',
+          node: deployPagesNode,
+        })
+      }
+    },
+
+    YAMLPair(node: AST.YAMLPair): void {
+      if (!node.key || node.key.type !== 'YAMLScalar' || typeof node.key.value !== 'string') {
+        return
+      }
+
+      if (node.key.value === 'uses' && isDeployPagesAction(node.value)) {
+        deployPagesNode = node
+        return
+      }
+
+      if (!isTopLevelPair(node) || node.value?.type !== 'YAMLMapping') {
+        return
+      }
+
+      if (node.key.value === 'permissions') {
+        permissions = node.value
+      } else if (node.key.value === 'concurrency') {
+        concurrency = node.value
+      }
+    },
+  }
+}

--- a/packages/plugin-github-actions/test/github-pages.test.ts
+++ b/packages/plugin-github-actions/test/github-pages.test.ts
@@ -1,0 +1,134 @@
+import { RuleTester } from 'eslint'
+import * as parser from 'yaml-eslint-parser'
+import * as rule from '../src/rules/github-pages.ts'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    parser,
+  },
+})
+
+const filename = '/workspace/.github/workflows/ci.yml'
+
+ruleTester.run('githubPages', rule, {
+  invalid: [
+    {
+      code: `
+name: CI
+
+jobs:
+  deploy:
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4`,
+      errors: [
+        {
+          messageId: 'missingGithubPagesPermissions',
+        },
+        {
+          messageId: 'missingGithubPagesConcurrency',
+        },
+      ],
+      filename,
+    },
+    {
+      code: `
+name: CI
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4`,
+      errors: [
+        {
+          messageId: 'missingGithubPagesConcurrency',
+        },
+      ],
+      filename,
+    },
+    {
+      code: `
+name: CI
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v3`,
+      errors: [
+        {
+          messageId: 'missingGithubPagesConcurrency',
+        },
+      ],
+      filename,
+    },
+    {
+      code: `
+name: CI
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4`,
+      errors: [
+        {
+          messageId: 'missingGithubPagesPermissions',
+        },
+      ],
+      filename,
+    },
+  ],
+  valid: [
+    {
+      code: `
+name: CI
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4`,
+      filename,
+    },
+    {
+      code: `
+name: Release
+
+jobs:
+  deploy:
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4`,
+      filename: '/workspace/.github/workflows/release.yml',
+    },
+  ],
+})

--- a/packages/plugin-github-actions/test/index.ts
+++ b/packages/plugin-github-actions/test/index.ts
@@ -1,6 +1,7 @@
 import './action-versions.test.ts'
 import './ci-versions.test.ts'
 import './fail-fast.test.ts'
+import './github-pages.test.ts'
 import './github-token.test.ts'
 import './matrix.test.ts'
 import './needs.test.ts'


### PR DESCRIPTION
Adds a GitHub Actions lint rule that requires GitHub Pages deploy workflows in ci.yml to declare the required Pages permissions and concurrency group.