### PR TITLE
feature: disallow imports in e2e tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,4 +11,10 @@ export default [
     files: ['packages/plugin-*/test/**/*.test.ts'],
     ...eslintPlugin.configs['tests-recommended'],
   },
+  {
+    files: ['packages/e2e/test/**/*.ts'],
+    rules: {
+      'e2e/no-imports': 'off',
+    },
+  },
 ]

--- a/packages/e2e/fixtures/sample-e2e-no-imports/e2e/helper.ts
+++ b/packages/e2e/fixtures/sample-e2e-no-imports/e2e/helper.ts
@@ -1,0 +1,1 @@
+export const helper = (): void => {}

--- a/packages/e2e/fixtures/sample-e2e-no-imports/e2e/main.ts
+++ b/packages/e2e/fixtures/sample-e2e-no-imports/e2e/main.ts
@@ -1,0 +1,6 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { helper } from './helper.ts'
+
+export const test: Test = async () => {
+  helper()
+}

--- a/packages/e2e/fixtures/sample-e2e-no-imports/eslint.config.js
+++ b/packages/e2e/fixtures/sample-e2e-no-imports/eslint.config.js
@@ -1,0 +1,3 @@
+import * as config from '../../../plugin/index.js'
+
+export default config.default

--- a/packages/e2e/fixtures/sample-e2e-no-imports/expected.json
+++ b/packages/e2e/fixtures/sample-e2e-no-imports/expected.json
@@ -1,0 +1,6 @@
+[
+  {
+    "filePath": "e2e/main.ts:2",
+    "message": "E2E tests must be self-contained. Only type imports from @lvce-editor/test-with-playwright are allowed."
+  }
+]

--- a/packages/e2e/fixtures/sample-e2e-no-imports/package.json
+++ b/packages/e2e/fixtures/sample-e2e-no-imports/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "sample-e2e-no-imports",
+  "version": "0.0.0-dev",
+  "license": "MIT",
+  "type": "module",
+  "main": "e2e/main.ts",
+  "scripts": {
+    "lint": "eslint .",
+    "lint:ci": "eslint . --format json --output-file result.json"
+  }
+}

--- a/packages/e2e/fixtures/sample-e2e-no-imports/tsconfig.json
+++ b/packages/e2e/fixtures/sample-e2e-no-imports/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "checkJs": true,
+    "target": "esnext",
+    "types": ["node"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "assumeChangesOnlyAffectDirectDependencies": true,
+    "strict": true,
+    "noImplicitAny": false,
+    "composite": true,
+    "allowImportingTsExtensions": true,
+    "rootDir": "."
+  },
+  "include": ["e2e"]
+}

--- a/packages/e2e/test/sample-e2e-no-imports.test.ts
+++ b/packages/e2e/test/sample-e2e-no-imports.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from '@jest/globals'
+import { runFixture } from './util.ts'
+
+test('sample-e2e-no-imports', async () => {
+  const { expected, parsed } = await runFixture('sample-e2e-no-imports')
+  expect(parsed).toEqual(expected)
+})

--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -1,5 +1,6 @@
 import type { Linter } from 'eslint'
 import * as noDirectClick from './rules/no-direct-click.ts'
+import * as noImports from './rules/no-imports.ts'
 import * as noInlineLocatorInExpect from './rules/no-inline-locator-in-expect.ts'
 import * as noInlineNthInExpect from './rules/no-inline-nth-in-expect.ts'
 import * as noLazyNthVariableName from './rules/no-lazy-nth-variable-name.ts'
@@ -16,6 +17,7 @@ const plugin = {
   },
   rules: {
     'no-direct-click': noDirectClick,
+    'no-imports': noImports,
     'no-inline-locator-in-expect': noInlineLocatorInExpect,
     'no-inline-nth-in-expect': noInlineNthInExpect,
     'no-lazy-nth-variable-name': noLazyNthVariableName,
@@ -34,6 +36,7 @@ const recommended: Linter.Config[] = [
     },
     rules: {
       'e2e/no-direct-click': 'error',
+      'e2e/no-imports': 'error',
       'e2e/no-inline-locator-in-expect': 'error',
       'e2e/no-inline-nth-in-expect': 'error',
       'e2e/no-lazy-nth-variable-name': 'error',

--- a/packages/plugin-e2e/src/rules/no-imports.ts
+++ b/packages/plugin-e2e/src/rules/no-imports.ts
@@ -1,0 +1,49 @@
+import type { Rule } from 'eslint'
+import type * as ESTree from 'estree'
+
+const allowedTypeImportSource = '@lvce-editor/test-with-playwright'
+
+interface ImportDeclaration extends ESTree.BaseNode {
+  readonly importKind?: 'type' | 'value'
+  readonly source: ESTree.Literal
+  readonly specifiers: readonly ImportSpecifier[]
+  readonly type: 'ImportDeclaration'
+}
+
+interface ImportSpecifier extends ESTree.BaseNode {
+  readonly importKind?: 'type' | 'value'
+}
+
+export const meta: Rule.RuleMetaData = {
+  docs: {
+    description: 'Disallow imports in e2e tests except type imports from @lvce-editor/test-with-playwright',
+  },
+  messages: {
+    noImports: 'E2E tests must be self-contained. Only type imports from @lvce-editor/test-with-playwright are allowed.',
+  },
+  type: 'problem',
+}
+
+const isAllowedTypeImport = (node: ImportDeclaration): boolean => {
+  if (node.source.value !== allowedTypeImportSource) {
+    return false
+  }
+  if (node.importKind === 'type') {
+    return true
+  }
+  return node.specifiers.length > 0 && node.specifiers.every((specifier) => specifier.importKind === 'type')
+}
+
+export const create = (context: Rule.RuleContext): Rule.RuleListener => {
+  return {
+    ImportDeclaration(node: ImportDeclaration): void {
+      if (isAllowedTypeImport(node)) {
+        return
+      }
+      context.report({
+        messageId: 'noImports',
+        node,
+      })
+    },
+  }
+}

--- a/packages/plugin-e2e/test/index.ts
+++ b/packages/plugin-e2e/test/index.ts
@@ -1,4 +1,5 @@
 import './no-direct-click.test.ts'
+import './no-imports.test.ts'
 import './no-lazy-nth-variable-name.test.ts'
 import './no-inline-locator-in-expect.test.ts'
 import './no-inline-nth-in-expect.test.ts'

--- a/packages/plugin-e2e/test/no-imports.test.ts
+++ b/packages/plugin-e2e/test/no-imports.test.ts
@@ -1,0 +1,50 @@
+import { RuleTester } from 'eslint'
+import tseslint from 'typescript-eslint'
+import * as rule from '../src/rules/no-imports.ts'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    parser: tseslint.parser,
+    sourceType: 'module',
+  },
+})
+
+ruleTester.run('no-imports', rule, {
+  invalid: [
+    {
+      code: `import { helper } from './helper.ts'`,
+      errors: [{ messageId: 'noImports' }],
+    },
+    {
+      code: `import type { Helper } from './helper.ts'`,
+      errors: [{ messageId: 'noImports' }],
+    },
+    {
+      code: `import { test } from '@lvce-editor/test-with-playwright'`,
+      errors: [{ messageId: 'noImports' }],
+    },
+    {
+      code: `import { type Test, test } from '@lvce-editor/test-with-playwright'`,
+      errors: [{ messageId: 'noImports' }],
+    },
+    {
+      code: `import '@lvce-editor/test-with-playwright'`,
+      errors: [{ messageId: 'noImports' }],
+    },
+  ],
+  valid: [
+    {
+      code: `export const test = async () => {}`,
+    },
+    {
+      code: `import type { Test } from '@lvce-editor/test-with-playwright'`,
+    },
+    {
+      code: `import { type Test } from '@lvce-editor/test-with-playwright'`,
+    },
+    {
+      code: `import type * as PlaywrightTypes from '@lvce-editor/test-with-playwright'`,
+    },
+  ],
+})


### PR DESCRIPTION
Adds an e2e ESLint rule that keeps tests self-contained by rejecting imports. Type-only imports from `@lvce-editor/test-with-playwright` remain allowed.