### PR TITLE
feature: hoist static virtual dom nodes

### DIFF
--- a/packages/plugin-virtual-dom/src/index.ts
+++ b/packages/plugin-virtual-dom/src/index.ts
@@ -1,5 +1,6 @@
 import type { Linter } from 'eslint'
 import * as clickableDivNeedsRole from './rules/clickable-div-needs-role.ts'
+import * as hoistStaticNodes from './rules/hoist-static-nodes.ts'
 import * as noEmptyAria from './rules/no-empty-aria.ts'
 import * as noEmptyClassName from './rules/no-empty-class-name.ts'
 import * as noInlineEventHandlers from './rules/no-inline-event-handlers.ts'
@@ -20,6 +21,7 @@ const plugin = {
   },
   rules: {
     'clickable-div-needs-role': clickableDivNeedsRole,
+    'hoist-static-nodes': hoistStaticNodes,
     'no-empty-aria': noEmptyAria,
     'no-empty-class-name': noEmptyClassName,
     'no-inline-event-handlers': noInlineEventHandlers,
@@ -42,6 +44,7 @@ const recommended: Linter.Config[] = [
     },
     rules: {
       'virtual-dom/clickable-div-needs-role': 'error',
+      'virtual-dom/hoist-static-nodes': 'error',
       'virtual-dom/no-empty-aria': 'error',
       'virtual-dom/no-empty-class-name': 'error',
       'virtual-dom/no-inline-event-handlers': 'error',

--- a/packages/plugin-virtual-dom/src/rules/hoist-static-nodes.ts
+++ b/packages/plugin-virtual-dom/src/rules/hoist-static-nodes.ts
@@ -1,0 +1,110 @@
+import type { Rule, Scope, SourceCode } from 'eslint'
+import type * as ESTree from 'estree'
+import { isVirtualDomNode } from './ast.ts'
+
+export const meta: Rule.RuleMetaData = {
+  docs: {
+    description: 'Require static virtual-dom nodes created inside functions to be hoisted to module scope',
+  },
+  messages: {
+    hoistStaticNode: 'Hoist this static virtual-dom node to module scope.',
+  },
+  type: 'suggestion',
+}
+
+const isFunctionNode = (node: ESTree.Node): boolean => {
+  return ['ArrowFunctionExpression', 'FunctionDeclaration', 'FunctionExpression'].includes(node.type)
+}
+
+const findVariable = (sourceCode: SourceCode, identifier: ESTree.Identifier): Scope.Variable | undefined => {
+  let scope: Scope.Scope | null = sourceCode.getScope(identifier)
+  while (scope) {
+    const variable = scope.set.get(identifier.name)
+    if (variable) {
+      return variable
+    }
+    scope = scope.upper
+  }
+  return undefined
+}
+
+const isStaticModuleVariable = (variable: Scope.Variable): boolean => {
+  if (!['global', 'module'].includes(variable.scope.type)) {
+    return false
+  }
+  return variable.defs.every((definition) => {
+    if (['ClassName', 'FunctionName', 'ImportBinding'].includes(definition.type)) {
+      return true
+    }
+    return definition.type === 'Variable' && definition.parent.kind === 'const'
+  })
+}
+
+const isStaticIdentifier = (sourceCode: SourceCode, node: ESTree.Identifier): boolean => {
+  const variable = findVariable(sourceCode, node)
+  return Boolean(variable && isStaticModuleVariable(variable))
+}
+
+const isStaticProperty = (sourceCode: SourceCode, node: ESTree.Property | ESTree.SpreadElement): boolean => {
+  if (node.type === 'SpreadElement' || node.kind !== 'init' || node.method) {
+    return false
+  }
+  if (node.computed && !isStaticExpression(sourceCode, node.key)) {
+    return false
+  }
+  return isStaticExpression(sourceCode, node.value)
+}
+
+const isStaticExpression = (sourceCode: SourceCode, node: ESTree.Node | null): boolean => {
+  if (!node) {
+    return true
+  }
+  switch (node.type) {
+    case 'ArrayExpression':
+      return node.elements.every((element) => !element || (element.type !== 'SpreadElement' && isStaticExpression(sourceCode, element)))
+    case 'BinaryExpression':
+    case 'LogicalExpression':
+      return isStaticExpression(sourceCode, node.left) && isStaticExpression(sourceCode, node.right)
+    case 'ConditionalExpression':
+      return (
+        isStaticExpression(sourceCode, node.test) && isStaticExpression(sourceCode, node.consequent) && isStaticExpression(sourceCode, node.alternate)
+      )
+    case 'Identifier':
+      return isStaticIdentifier(sourceCode, node)
+    case 'Literal':
+      return true
+    case 'MemberExpression':
+      return (
+        isStaticExpression(sourceCode, node.object) &&
+        (!node.computed || (node.property.type !== 'PrivateIdentifier' && isStaticExpression(sourceCode, node.property)))
+      )
+    case 'ObjectExpression':
+      return node.properties.every((property) => isStaticProperty(sourceCode, property))
+    case 'TemplateLiteral':
+      return node.expressions.every((expression) => isStaticExpression(sourceCode, expression))
+    case 'UnaryExpression':
+      return node.operator !== 'delete' && isStaticExpression(sourceCode, node.argument)
+    default:
+      return false
+  }
+}
+
+export const create = (context: Rule.RuleContext): Rule.RuleListener => {
+  return {
+    ObjectExpression(node: ESTree.ObjectExpression): void {
+      if (!isVirtualDomNode(node)) {
+        return
+      }
+      if (!context.sourceCode.getAncestors(node).some(isFunctionNode)) {
+        return
+      }
+      if (!isStaticExpression(context.sourceCode, node)) {
+        return
+      }
+      context.report({
+        messageId: 'hoistStaticNode',
+        node,
+      })
+    },
+  }
+}

--- a/packages/plugin-virtual-dom/test/hoist-static-nodes.test.ts
+++ b/packages/plugin-virtual-dom/test/hoist-static-nodes.test.ts
@@ -1,0 +1,129 @@
+import { RuleTester } from 'eslint'
+import * as rule from '../src/rules/hoist-static-nodes.ts'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+})
+
+ruleTester.run('hoist-static-nodes', rule, {
+  invalid: [
+    {
+      code: `
+import { ClassNames, VirtualDomElements } from './constants.js'
+
+export const getSearchHeader = (message) => {
+  return [
+    {
+      childCount: 2,
+      className: ClassNames.SearchHeaderDetails,
+      type: VirtualDomElements.Div,
+    },
+    getSearchMessage(message),
+  ]
+}
+`,
+      errors: [
+        {
+          column: 5,
+          endColumn: 6,
+          endLine: 10,
+          line: 6,
+          messageId: 'hoistStaticNode',
+        },
+      ],
+    },
+    {
+      code: `
+import { VirtualDomElements } from './constants.js'
+
+const staticAttributes = {
+  ariaHidden: true,
+}
+
+export function getSeparator() {
+  return {
+    aria: staticAttributes,
+    childCount: 0,
+    type: VirtualDomElements.Div,
+  }
+}
+`,
+      errors: [
+        {
+          messageId: 'hoistStaticNode',
+        },
+      ],
+    },
+  ],
+  valid: [
+    {
+      code: `
+import { ClassNames, VirtualDomElements } from './constants.js'
+
+const searchHeader = {
+  childCount: 2,
+  className: ClassNames.SearchHeaderDetails,
+  type: VirtualDomElements.Div,
+}
+`,
+    },
+    {
+      code: `
+import { VirtualDomElements } from './constants.js'
+
+export const getMessage = (message) => {
+  return {
+    childCount: 0,
+    text: message,
+    type: VirtualDomElements.Div,
+  }
+}
+`,
+    },
+    {
+      code: `
+import { VirtualDomElements } from './constants.js'
+
+export const getLabelNode = () => {
+  return {
+    childCount: 0,
+    label: getLabel(),
+    type: VirtualDomElements.Div,
+  }
+}
+`,
+    },
+    {
+      code: `
+import { VirtualDomElements } from './constants.js'
+
+export const getNode = () => {
+  const className = 'Button'
+  return {
+    childCount: 0,
+    className,
+    type: VirtualDomElements.Div,
+  }
+}
+`,
+    },
+    {
+      code: `
+import { VirtualDomElements } from './constants.js'
+
+let className = 'Button'
+
+export const getNode = () => {
+  return {
+    childCount: 0,
+    className,
+    type: VirtualDomElements.Div,
+  }
+}
+`,
+    },
+  ],
+})

--- a/packages/plugin-virtual-dom/test/index.ts
+++ b/packages/plugin-virtual-dom/test/index.ts
@@ -1,4 +1,5 @@
 import './clickable-div-needs-role.test.ts'
+import './hoist-static-nodes.test.ts'
 import './no-empty-aria.test.ts'
 import './no-empty-class-name.test.ts'
 import './no-inline-event-handlers.test.ts'


### PR DESCRIPTION
Adds a recommended virtual-dom rule that reports safely hoistable static node objects created inside functions. Dynamic calls, function parameters, local bindings, and mutable module values remain unreported.