### PR TITLE
feature: disallow manual class name concatenation

### DIFF
--- a/packages/e2e/fixtures/sample-virtual-dom-rules/expected.json
+++ b/packages/e2e/fixtures/sample-virtual-dom-rules/expected.json
@@ -54,5 +54,9 @@
   {
     "filePath": "src/main.ts:78",
     "message": "Use `mergeClassNames(...)` instead of manually concatenating `className`."
+  },
+  {
+    "filePath": "src/main.ts:84",
+    "message": "Use `mergeClassNames(...)` instead of manually concatenating `className`."
   }
 ]

--- a/packages/e2e/fixtures/sample-virtual-dom-rules/src/main.ts
+++ b/packages/e2e/fixtures/sample-virtual-dom-rules/src/main.ts
@@ -79,6 +79,13 @@ const multiClassName = {
   type: VirtualDomElements.Div,
 }
 
+const getSearchResultClassName = (focused: boolean): string => {
+  if (focused) {
+    return ClassNames.TreeItem + ' ' + ClassNames.TreeItemActive
+  }
+  return ClassNames.TreeItem
+}
+
 export const nodes = [
   rawTextChildren,
   invalidChildCount,
@@ -93,4 +100,5 @@ export const nodes = [
   clickableDiv,
   emptyAria,
   multiClassName,
+  getSearchResultClassName,
 ]

--- a/packages/plugin-virtual-dom/src/rules/prefer-merge-class-names.ts
+++ b/packages/plugin-virtual-dom/src/rules/prefer-merge-class-names.ts
@@ -3,6 +3,8 @@ import type * as ESTree from 'estree'
 import {
   getStaticPropertyName,
   isBinaryExpressionNode,
+  isIdentifierNode,
+  isMemberExpressionNode,
   isPropertyNode,
   isStringLiteral,
   isTemplateLiteralNode,
@@ -12,6 +14,10 @@ import {
 
 const isClassNameKey = (node: PropertyNode): boolean => {
   return getStaticPropertyName(node) === 'className'
+}
+
+const isClassNameProperty = (node: unknown): boolean => {
+  return isPropertyNode(node) && isClassNameKey(node)
 }
 
 const isStringLiteralWithSpace = (node: unknown): boolean => {
@@ -44,6 +50,30 @@ const isManualClassNameConcatenation = (node: unknown): boolean => {
   )
 }
 
+const hasClassNamesReference = (node: unknown): boolean => {
+  if (isMemberExpressionNode(node)) {
+    return (
+      (isIdentifierNode(node.object) && node.object.name === 'ClassNames') ||
+      hasClassNamesReference(node.object) ||
+      (node.computed && hasClassNamesReference(node.property))
+    )
+  }
+  if (isBinaryExpressionNode(node)) {
+    return hasClassNamesReference(node.left) || hasClassNamesReference(node.right)
+  }
+  if (isTemplateLiteralNode(node)) {
+    return node.expressions.some(hasClassNamesReference)
+  }
+  return false
+}
+
+const getParent = (node: unknown): unknown => {
+  if (typeof node === 'object' && node !== null && 'parent' in node) {
+    return node.parent
+  }
+  return undefined
+}
+
 export const meta: Rule.RuleMetaData = {
   docs: {
     description: 'Prefer mergeClassNames for composing virtual-dom className values',
@@ -55,7 +85,22 @@ export const meta: Rule.RuleMetaData = {
 }
 
 export const create = (context: Rule.RuleContext): Rule.RuleListener => {
+  const reportNamespacedClassNameComposition = (node: unknown): void => {
+    if (!isManualClassNameConcatenation(node) || !hasClassNamesReference(node)) {
+      return
+    }
+    const parent = getParent(node)
+    if (isManualClassNameConcatenation(parent) || isClassNameProperty(parent)) {
+      return
+    }
+    context.report({
+      messageId: 'preferMergeClassNames',
+      node: node as ESTree.Node,
+    })
+  }
+
   return {
+    BinaryExpression: reportNamespacedClassNameComposition,
     Property(node: unknown): void {
       if (!isPropertyNode(node) || !isClassNameKey(node) || !isManualClassNameConcatenation(node.value)) {
         return
@@ -65,5 +110,6 @@ export const create = (context: Rule.RuleContext): Rule.RuleListener => {
         node: node.value as ESTree.Node,
       })
     },
+    TemplateLiteral: reportNamespacedClassNameComposition,
   }
 }

--- a/packages/plugin-virtual-dom/test/prefer-merge-class-names.test.ts
+++ b/packages/plugin-virtual-dom/test/prefer-merge-class-names.test.ts
@@ -95,6 +95,44 @@ const dom = {
         },
       ],
     },
+    {
+      code: `
+const getSearchResultClassName = (focused) => {
+  if (focused) {
+    return ClassNames.TreeItem + ' ' + ClassNames.TreeItemActive
+  }
+  return ClassNames.TreeItem
+}
+`,
+      errors: [
+        {
+          column: 12,
+          endColumn: 65,
+          endLine: 4,
+          line: 4,
+          messageId: 'preferMergeClassNames',
+        },
+      ],
+    },
+    {
+      code: `
+const getSearchResultClassName = (focused) => {
+  if (focused) {
+    return \`\${ClassNames.TreeItem} \${ClassNames.TreeItemActive}\`
+  }
+  return ClassNames.TreeItem
+}
+`,
+      errors: [
+        {
+          column: 12,
+          endColumn: 65,
+          endLine: 4,
+          line: 4,
+          messageId: 'preferMergeClassNames',
+        },
+      ],
+    },
   ],
   valid: [
     {
@@ -150,6 +188,21 @@ const dom = {
 const dom = {
   type: 'div',
   [classNameProperty]: \`\${baseClass} \${selectedClass}\`,
+}
+`,
+    },
+    {
+      code: `
+const label = firstName + ' ' + lastName
+`,
+    },
+    {
+      code: `
+const getSearchResultClassName = (focused) => {
+  if (focused) {
+    return mergeClassNames(ClassNames.TreeItem, ClassNames.TreeItemActive)
+  }
+  return ClassNames.TreeItem
 }
 `,
     },


### PR DESCRIPTION
Summary:
- detect manual `ClassNames.*` composition outside virtual DOM object properties
- require `mergeClassNames(...)` for binary and template-literal composition
- add focused unit and e2e regression coverage