### PR TITLE
feature: forbid conditional virtual dom spreads

### DIFF
--- a/packages/plugin-virtual-dom/src/index.ts
+++ b/packages/plugin-virtual-dom/src/index.ts
@@ -1,6 +1,7 @@
 import type { Linter } from 'eslint'
 import * as clickableDivNeedsRole from './rules/clickable-div-needs-role.ts'
 import * as hoistStaticNodes from './rules/hoist-static-nodes.ts'
+import * as noConditionalSpread from './rules/no-conditional-spread.ts'
 import * as noEmptyAria from './rules/no-empty-aria.ts'
 import * as noEmptyClassName from './rules/no-empty-class-name.ts'
 import * as noInlineEventHandlers from './rules/no-inline-event-handlers.ts'
@@ -24,6 +25,7 @@ const plugin = {
   rules: {
     'clickable-div-needs-role': clickableDivNeedsRole,
     'hoist-static-nodes': hoistStaticNodes,
+    'no-conditional-spread': noConditionalSpread,
     'no-empty-aria': noEmptyAria,
     'no-empty-class-name': noEmptyClassName,
     'no-inline-event-handlers': noInlineEventHandlers,
@@ -49,6 +51,7 @@ const recommended: Linter.Config[] = [
     rules: {
       'virtual-dom/clickable-div-needs-role': 'error',
       'virtual-dom/hoist-static-nodes': 'error',
+      'virtual-dom/no-conditional-spread': 'error',
       'virtual-dom/no-empty-aria': 'error',
       'virtual-dom/no-empty-class-name': 'error',
       'virtual-dom/no-inline-event-handlers': 'error',

--- a/packages/plugin-virtual-dom/src/rules/no-conditional-spread.ts
+++ b/packages/plugin-virtual-dom/src/rules/no-conditional-spread.ts
@@ -1,0 +1,46 @@
+import type { Rule } from 'eslint'
+import type * as ESTree from 'estree'
+import { isArrayExpressionNode, isTextCall, isVirtualDomNode } from './ast.ts'
+
+export const meta: Rule.RuleMetaData = {
+  docs: {
+    description: 'Disallow conditional spreads in virtual-dom arrays',
+  },
+  messages: {
+    noConditionalSpread: 'Move conditional virtual-dom children into a helper function and spread the helper result.',
+  },
+  type: 'suggestion',
+}
+
+type ConditionalSpread = ESTree.SpreadElement & {
+  argument: ESTree.ConditionalExpression
+}
+
+const isConditionalSpread = (node: ESTree.Expression | ESTree.SpreadElement | null): node is ConditionalSpread => {
+  return node?.type === 'SpreadElement' && node.argument.type === 'ConditionalExpression'
+}
+
+const isVirtualDomArray = (node: unknown): boolean => {
+  return isArrayExpressionNode(node) && node.elements.some((element) => isVirtualDomNode(element) || isTextCall(element))
+}
+
+const addsVirtualDomChildren = (spread: ConditionalSpread): boolean => {
+  return isVirtualDomArray(spread.argument.consequent) || isVirtualDomArray(spread.argument.alternate)
+}
+
+export const create = (context: Rule.RuleContext): Rule.RuleListener => {
+  return {
+    ArrayExpression(node: ESTree.ArrayExpression): void {
+      const conditionalSpreads = node.elements.filter(isConditionalSpread)
+      if (!isVirtualDomArray(node) && !conditionalSpreads.some(addsVirtualDomChildren)) {
+        return
+      }
+      for (const spread of conditionalSpreads) {
+        context.report({
+          messageId: 'noConditionalSpread',
+          node: spread,
+        })
+      }
+    },
+  }
+}

--- a/packages/plugin-virtual-dom/test/index.ts
+++ b/packages/plugin-virtual-dom/test/index.ts
@@ -1,5 +1,6 @@
 import './clickable-div-needs-role.test.ts'
 import './hoist-static-nodes.test.ts'
+import './no-conditional-spread.test.ts'
 import './no-empty-aria.test.ts'
 import './no-empty-class-name.test.ts'
 import './no-inline-event-handlers.test.ts'

--- a/packages/plugin-virtual-dom/test/no-conditional-spread.test.ts
+++ b/packages/plugin-virtual-dom/test/no-conditional-spread.test.ts
@@ -1,0 +1,78 @@
+import { RuleTester } from 'eslint'
+import * as rule from '../src/rules/no-conditional-spread.ts'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+})
+
+ruleTester.run('no-conditional-spread', rule, {
+  invalid: [
+    {
+      code: `
+const dom = [
+  {
+    childCount: 1,
+    type: VirtualDomElements.Div,
+  },
+  ...(coverImageUrl
+    ? [
+        {
+          alt: \`\${card.name} cover\`,
+          childCount: 0,
+          src: coverImageUrl,
+          type: VirtualDomElements.Img,
+        },
+      ]
+    : []),
+]
+`,
+      errors: [
+        {
+          messageId: 'noConditionalSpread',
+        },
+      ],
+    },
+    {
+      code: `
+const dom = [
+  ...(enabled
+    ? [
+        {
+          childCount: 0,
+          type: VirtualDomElements.Div,
+        },
+      ]
+    : []),
+]
+`,
+      errors: [
+        {
+          messageId: 'noConditionalSpread',
+        },
+      ],
+    },
+  ],
+  valid: [
+    {
+      code: `
+const dom = [
+  {
+    childCount: children.length,
+    type: VirtualDomElements.Div,
+  },
+  ...getChildren(enabled),
+]
+`,
+    },
+    {
+      code: `
+const values = [
+  ...(enabled ? ['one'] : []),
+]
+`,
+    },
+  ],
+})


### PR DESCRIPTION
Adds a recommended virtual-dom lint rule that rejects ternary expressions spread directly into virtual-DOM arrays and guides authors toward a helper function. Includes focused coverage for conditional virtual-DOM children, helper spreads, and non-DOM arrays.