### PR TITLE
fix: publish extension json eslint plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: npm publish --access public
+        working-directory: ./.tmp/plugin-extension-json
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - run: npm publish --access public
         working-directory: ./.tmp/plugin-rpc
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
The v17.3.0 root package references @lvce-editor/eslint-plugin-extension-json@17.3.0, but the release workflow does not publish that build artifact. Add the missing npm publish step so the next patch release is installable.