### PR TITLE
fix: ignore class constants in test fixtures

### DIFF
--- a/packages/plugin-virtual-dom/src/index.ts
+++ b/packages/plugin-virtual-dom/src/index.ts
@@ -112,6 +112,12 @@ export const strict: Linter.Config[] = [
       'virtual-dom/valid-node-shape': 'error',
     },
   },
+  {
+    files: ['**/test/**/*.{js,mjs,cjs,ts,mts,cts}', '**/tests/**/*.{js,mjs,cjs,ts,mts,cts}', '**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}'],
+    rules: {
+      'virtual-dom/prefer-class-name-constants': 'off',
+    },
+  },
 ]
 
 export default recommended

--- a/packages/plugin-virtual-dom/test/recommended-config.test.ts
+++ b/packages/plugin-virtual-dom/test/recommended-config.test.ts
@@ -49,3 +49,31 @@ const node = {
   equal(strictMessages.length, 1)
   equal(strictMessages[0].ruleId, 'virtual-dom/valid-event-properties')
 })
+
+void test('allows literal class names in strict test fixtures', () => {
+  const code = `
+const node = {
+  ariaLabel: 'Test',
+  childCount: 0,
+  className: 'Button',
+  type: VirtualDomElements.Button,
+}
+`
+
+  const linter = new Linter()
+  const sourceMessages = linter.verify(code, strict, {
+    filename: 'src/getNode.js',
+  })
+  let hasClassNameDiagnostic = false
+  for (const message of sourceMessages) {
+    if (message.ruleId === 'virtual-dom/prefer-class-name-constants') {
+      hasClassNameDiagnostic = true
+    }
+  }
+  equal(hasClassNameDiagnostic, true)
+
+  const testMessages = linter.verify(code, strict, {
+    filename: 'test/getNode.test.js',
+  })
+  deepEqual(testMessages, [])
+})


### PR DESCRIPTION
Keep prefer-class-name-constants enabled for production code while following the preset's existing convention that expected virtual-DOM fixture objects may use literal values. This removes snapshot noise without requiring consumer-side strict-rule overrides.