### PR TITLE
fix: hoist nodes with static merged class names

### DIFF
--- a/packages/plugin-virtual-dom/src/rules/hoist-static-nodes.ts
+++ b/packages/plugin-virtual-dom/src/rules/hoist-static-nodes.ts
@@ -45,6 +45,39 @@ const isStaticIdentifier = (sourceCode: SourceCode, node: ESTree.Identifier): bo
   return Boolean(variable && isStaticModuleVariable(variable))
 }
 
+const isMergeClassNamesImport = (variable: Scope.Variable): boolean => {
+  return variable.defs.some((definition) => {
+    if (definition.type !== 'ImportBinding' || definition.node.type !== 'ImportSpecifier') {
+      return false
+    }
+    return definition.node.imported.type === 'Identifier'
+      ? definition.node.imported.name === 'mergeClassNames'
+      : definition.node.imported.value === 'mergeClassNames'
+  })
+}
+
+const isNamespaceImport = (variable: Scope.Variable): boolean => {
+  return variable.defs.some((definition) => definition.type === 'ImportBinding' && definition.node.type === 'ImportNamespaceSpecifier')
+}
+
+const isMergeClassNamesCallee = (sourceCode: SourceCode, node: ESTree.Expression | ESTree.Super): boolean => {
+  if (node.type === 'Identifier') {
+    const variable = findVariable(sourceCode, node)
+    return Boolean(variable && isMergeClassNamesImport(variable))
+  }
+  if (
+    node.type !== 'MemberExpression' ||
+    node.computed ||
+    node.object.type !== 'Identifier' ||
+    node.property.type !== 'Identifier' ||
+    node.property.name !== 'mergeClassNames'
+  ) {
+    return false
+  }
+  const variable = findVariable(sourceCode, node.object)
+  return Boolean(variable && isNamespaceImport(variable))
+}
+
 const isPropertyMutation = (sourceCode: SourceCode, identifier: ESTree.Identifier): boolean => {
   const ancestors = sourceCode.getAncestors(identifier)
   let current: ESTree.Node = identifier
@@ -112,6 +145,11 @@ const isStaticExpression = (sourceCode: SourceCode, node: ESTree.Node | null): b
     case 'ConditionalExpression':
       return (
         isStaticExpression(sourceCode, node.test) && isStaticExpression(sourceCode, node.consequent) && isStaticExpression(sourceCode, node.alternate)
+      )
+    case 'CallExpression':
+      return (
+        isMergeClassNamesCallee(sourceCode, node.callee) &&
+        node.arguments.every((argument) => argument.type !== 'SpreadElement' && isStaticExpression(sourceCode, argument))
       )
     case 'Identifier':
       return isStaticIdentifier(sourceCode, node)

--- a/packages/plugin-virtual-dom/src/rules/hoist-static-nodes.ts
+++ b/packages/plugin-virtual-dom/src/rules/hoist-static-nodes.ts
@@ -50,9 +50,7 @@ const isMergeClassNamesImport = (variable: Scope.Variable): boolean => {
     if (definition.type !== 'ImportBinding' || definition.node.type !== 'ImportSpecifier') {
       return false
     }
-    return definition.node.imported.type === 'Identifier'
-      ? definition.node.imported.name === 'mergeClassNames'
-      : definition.node.imported.value === 'mergeClassNames'
+    return (definition.node.imported.type === 'Identifier' ? definition.node.imported.name : definition.node.imported.value) === 'mergeClassNames'
   })
 }
 
@@ -142,14 +140,14 @@ const isStaticExpression = (sourceCode: SourceCode, node: ESTree.Node | null): b
     case 'BinaryExpression':
     case 'LogicalExpression':
       return isStaticExpression(sourceCode, node.left) && isStaticExpression(sourceCode, node.right)
-    case 'ConditionalExpression':
-      return (
-        isStaticExpression(sourceCode, node.test) && isStaticExpression(sourceCode, node.consequent) && isStaticExpression(sourceCode, node.alternate)
-      )
     case 'CallExpression':
       return (
         isMergeClassNamesCallee(sourceCode, node.callee) &&
         node.arguments.every((argument) => argument.type !== 'SpreadElement' && isStaticExpression(sourceCode, argument))
+      )
+    case 'ConditionalExpression':
+      return (
+        isStaticExpression(sourceCode, node.test) && isStaticExpression(sourceCode, node.consequent) && isStaticExpression(sourceCode, node.alternate)
       )
     case 'Identifier':
       return isStaticIdentifier(sourceCode, node)

--- a/packages/plugin-virtual-dom/test/hoist-static-nodes.test.ts
+++ b/packages/plugin-virtual-dom/test/hoist-static-nodes.test.ts
@@ -57,6 +57,45 @@ export function getSeparator() {
         },
       ],
     },
+    {
+      code: `
+import { mergeClassNames, VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
+import * as ClassNames from './ClassNames.js'
+
+export const getCloseIcon = () => {
+  return {
+    childCount: 0,
+    className: mergeClassNames(ClassNames.MaskIcon, ClassNames.MaskIconClose),
+    type: VirtualDomElements.Div,
+  }
+}
+`,
+      errors: [
+        {
+          messageId: 'hoistStaticNode',
+        },
+      ],
+    },
+    {
+      code: `
+import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
+import * as ClassNames from './ClassNames.js'
+import * as MergeClassNames from './MergeClassNames.js'
+
+export const getCloseIcon = () => {
+  return {
+    childCount: 0,
+    className: MergeClassNames.mergeClassNames(ClassNames.MaskIcon, ClassNames.MaskIconClose),
+    type: VirtualDomElements.Div,
+  }
+}
+`,
+      errors: [
+        {
+          messageId: 'hoistStaticNode',
+        },
+      ],
+    },
   ],
   valid: [
     {
@@ -102,6 +141,39 @@ export const getLabelNode = () => {
   return {
     childCount: 0,
     label: getLabel(),
+    type: VirtualDomElements.Div,
+  }
+}
+`,
+    },
+    {
+      code: `
+import { mergeClassNames, VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
+import * as ClassNames from './ClassNames.js'
+
+export const getIcon = (iconClassName) => {
+  return {
+    childCount: 0,
+    className: mergeClassNames(ClassNames.MaskIcon, iconClassName),
+    type: VirtualDomElements.Div,
+  }
+}
+`,
+    },
+    {
+      code: `
+import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
+import * as ClassNames from './ClassNames.js'
+
+const mergeClassNames = (...classNames) => {
+  console.log(classNames)
+  return classNames.join(' ')
+}
+
+export const getCloseIcon = () => {
+  return {
+    childCount: 0,
+    className: mergeClassNames(ClassNames.MaskIcon, ClassNames.MaskIconClose),
     type: VirtualDomElements.Div,
   }
 }


### PR DESCRIPTION
Summary:
- treat imported `mergeClassNames` calls as static when all arguments are static
- cover direct and namespace imports while preserving dynamic-call behavior