### PR TITLE
feature: add eslint plugin e2e coverage

### DIFF
--- a/packages/e2e/fixtures/eslint.config.js
+++ b/packages/e2e/fixtures/eslint.config.js
@@ -1,0 +1,8 @@
+import devcontainerConfig from '../../plugin-devcontainer/src/index.ts'
+import e2eConfig from '../../plugin-e2e/src/index.ts'
+import extensionJsonConfig from '../../plugin-extension-json/src/index.ts'
+import githubActionsConfig from '../../plugin-github-actions/src/index.ts'
+import tsconfigConfig from '../../plugin-tsconfig/src/index.ts'
+import { strict as virtualDomStrictConfig } from '../../plugin-virtual-dom/src/index.ts'
+
+export default [...devcontainerConfig, ...e2eConfig, ...extensionJsonConfig, ...githubActionsConfig, ...tsconfigConfig, ...virtualDomStrictConfig]

--- a/packages/e2e/fixtures/invalid-needs-reference/.github/workflows/ci.yml
+++ b/packages/e2e/fixtures/invalid-needs-reference/.github/workflows/ci.yml
@@ -10,4 +10,4 @@ jobs:
     runs-on: ubuntu-24.04
     needs: ['not-found']
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7

--- a/packages/e2e/fixtures/invalid-needs-reference/expected.json
+++ b/packages/e2e/fixtures/invalid-needs-reference/expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "filePath": ".github/workflows/ci.yml:12",
+    "filePath": ".github/workflows/ci.yml:11",
     "message": "Unsupported needs value: not-found"
   }
 ]

--- a/packages/e2e/fixtures/invalid-working-directory/.github/workflows/ci.yml
+++ b/packages/e2e/fixtures/invalid-working-directory/.github/workflows/ci.yml
@@ -9,6 +9,6 @@ jobs:
   ci:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - run: npm test
         working-directory: ./not-found

--- a/packages/e2e/fixtures/invalid-working-directory/expected.json
+++ b/packages/e2e/fixtures/invalid-working-directory/expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "filePath": ".github/workflows/ci.yml:12",
+    "filePath": ".github/workflows/ci.yml:14",
     "message": "Working directory not found: ./not-found"
   }
 ]

--- a/packages/e2e/fixtures/plugin-devcontainer-allowed-image/.devcontainer/devcontainer.json
+++ b/packages/e2e/fixtures/plugin-devcontainer-allowed-image/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "image": "node:24",
+  "features": {
+    "ghcr.io/devcontainers/features/desktop-lite:1": {}
+  }
+}

--- a/packages/e2e/fixtures/plugin-devcontainer-desktop-lite-feature/.devcontainer/devcontainer.json
+++ b/packages/e2e/fixtures/plugin-devcontainer-desktop-lite-feature/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:24",
+  "features": {}
+}

--- a/packages/e2e/fixtures/plugin-e2e-prefer-filesystem-set-files/e2e/main.ts
+++ b/packages/e2e/fixtures/plugin-e2e-prefer-filesystem-set-files/e2e/main.ts
@@ -1,0 +1,4 @@
+export const test = async ({ FileSystem }) => {
+  await FileSystem.writeFile(file1, 'one')
+  await FileSystem.writeFile(file2, 'two')
+}

--- a/packages/e2e/fixtures/plugin-e2e-prefer-to-be-hidden/e2e/main.ts
+++ b/packages/e2e/fixtures/plugin-e2e-prefer-to-be-hidden/e2e/main.ts
@@ -1,0 +1,3 @@
+export const test = async ({ expect }) => {
+  await expect(panel).not.toBeVisible()
+}

--- a/packages/e2e/fixtures/plugin-extension-json-content-security-policy/extension.json
+++ b/packages/e2e/fixtures/plugin-extension-json-content-security-policy/extension.json
@@ -1,0 +1,3 @@
+{
+  "browser": "dist/main.js"
+}

--- a/packages/e2e/fixtures/plugin-extension-json-valid-keybindings/extension.json
+++ b/packages/e2e/fixtures/plugin-extension-json-valid-keybindings/extension.json
@@ -1,0 +1,8 @@
+{
+  "keybindings": [
+    {
+      "key": "Ctrl+Nope",
+      "command": "sample.run"
+    }
+  ]
+}

--- a/packages/e2e/fixtures/plugin-github-actions-fail-fast/.github/workflows/ci.yml
+++ b/packages/e2e/fixtures/plugin-github-actions-fail-fast/.github/workflows/ci.yml
@@ -1,0 +1,4 @@
+jobs:
+  pr:
+    runs-on: ubuntu-24.04
+    fail-fast: test

--- a/packages/e2e/fixtures/plugin-github-actions-github-token/.github/workflows/ci.yml
+++ b/packages/e2e/fixtures/plugin-github-actions-github-token/.github/workflows/ci.yml
@@ -1,0 +1,7 @@
+jobs:
+  publish-release:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo release
+        env:
+          GITHUB_TOKEN: 123

--- a/packages/e2e/fixtures/plugin-github-actions-max-parallel/.github/workflows/ci.yml
+++ b/packages/e2e/fixtures/plugin-github-actions-max-parallel/.github/workflows/ci.yml
@@ -1,0 +1,4 @@
+jobs:
+  pr:
+    runs-on: ubuntu-24.04
+    max-parallel: test

--- a/packages/e2e/fixtures/plugin-github-actions-node-version-file/.github/workflows/ci.yml
+++ b/packages/e2e/fixtures/plugin-github-actions-node-version-file/.github/workflows/ci.yml
@@ -1,0 +1,7 @@
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: abc

--- a/packages/e2e/fixtures/plugin-github-actions-npm-registry/.github/workflows/ci.yml
+++ b/packages/e2e/fixtures/plugin-github-actions-npm-registry/.github/workflows/ci.yml
@@ -1,0 +1,7 @@
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/setup-node@v6
+        with:
+          registry-url: https://example.com

--- a/packages/e2e/fixtures/plugin-github-actions-timeout-minutes/.github/workflows/ci.yml
+++ b/packages/e2e/fixtures/plugin-github-actions-timeout-minutes/.github/workflows/ci.yml
@@ -1,0 +1,4 @@
+jobs:
+  pr:
+    runs-on: ubuntu-24.04
+    timeout-minutes: test

--- a/packages/e2e/fixtures/plugin-tsconfig-assume-direct-dependencies/tsconfig.json
+++ b/packages/e2e/fixtures/plugin-tsconfig-assume-direct-dependencies/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "assumeChangesOnlyAffectDirectDependencies": false,
+    "allowImportingTsExtensions": true,
+    "exactOptionalPropertyTypes": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "NodeNext",
+    "noImplicitAny": true,
+    "noUncheckedSideEffectImports": true,
+    "skipLibCheck": false,
+    "strict": true
+  }
+}

--- a/packages/e2e/fixtures/plugin-tsconfig-exact-optional-property-types/tsconfig.json
+++ b/packages/e2e/fixtures/plugin-tsconfig-exact-optional-property-types/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "assumeChangesOnlyAffectDirectDependencies": true,
+    "allowImportingTsExtensions": true,
+    "exactOptionalPropertyTypes": false,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "NodeNext",
+    "noImplicitAny": true,
+    "noUncheckedSideEffectImports": true,
+    "skipLibCheck": false,
+    "strict": true
+  }
+}

--- a/packages/e2e/fixtures/plugin-tsconfig-force-consistent-casing/tsconfig.json
+++ b/packages/e2e/fixtures/plugin-tsconfig-force-consistent-casing/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "assumeChangesOnlyAffectDirectDependencies": true,
+    "allowImportingTsExtensions": true,
+    "exactOptionalPropertyTypes": true,
+    "forceConsistentCasingInFileNames": false,
+    "moduleResolution": "NodeNext",
+    "noImplicitAny": true,
+    "noUncheckedSideEffectImports": true,
+    "skipLibCheck": false,
+    "strict": true
+  }
+}

--- a/packages/e2e/fixtures/plugin-tsconfig-strict/tsconfig.json
+++ b/packages/e2e/fixtures/plugin-tsconfig-strict/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "assumeChangesOnlyAffectDirectDependencies": true,
+    "allowImportingTsExtensions": true,
+    "exactOptionalPropertyTypes": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "NodeNext",
+    "noImplicitAny": true,
+    "noUncheckedSideEffectImports": true,
+    "skipLibCheck": false,
+    "strict": false
+  }
+}

--- a/packages/e2e/fixtures/plugin-virtual-dom-accessible-control-name/src/main.ts
+++ b/packages/e2e/fixtures/plugin-virtual-dom-accessible-control-name/src/main.ts
@@ -1,0 +1,4 @@
+export const node = {
+  childCount: 0,
+  type: VirtualDomElements.Button,
+}

--- a/packages/e2e/fixtures/plugin-virtual-dom-clickable-div-role/src/main.ts
+++ b/packages/e2e/fixtures/plugin-virtual-dom-clickable-div-role/src/main.ts
@@ -1,0 +1,5 @@
+export const node = {
+  childCount: 0,
+  onClick: DomEventListenerFunctions.HandleClick,
+  type: VirtualDomElements.Div,
+}

--- a/packages/e2e/test/additional-plugin-configs.test.ts
+++ b/packages/e2e/test/additional-plugin-configs.test.ts
@@ -1,0 +1,182 @@
+import { expect, test } from '@jest/globals'
+import { runConfiguredFixture, runFixture } from './util.ts'
+
+const cases = [
+  {
+    expected: [
+      {
+        filePath: 'e2e/main.ts:3',
+        message:
+          'Use FileSystem.setFiles([...fileItems]) instead of multiple adjacent FileSystem.writeFile calls so files can be written in parallel.',
+      },
+    ],
+    name: 'plugin-e2e-prefer-filesystem-set-files',
+  },
+  {
+    expected: [
+      {
+        filePath: 'e2e/main.ts:2',
+        message: 'Use toBeHidden() instead of not.toBeVisible().',
+      },
+    ],
+    name: 'plugin-e2e-prefer-to-be-hidden',
+  },
+  {
+    expected: [
+      {
+        filePath: 'tsconfig.json:3',
+        message: 'assumeChangesOnlyAffectDirectDependencies rule should be enabled',
+      },
+    ],
+    name: 'plugin-tsconfig-assume-direct-dependencies',
+  },
+  {
+    expected: [
+      {
+        filePath: 'tsconfig.json:5',
+        message: 'exactOptionalPropertyTypes rule should be enabled',
+      },
+    ],
+    name: 'plugin-tsconfig-exact-optional-property-types',
+  },
+  {
+    expected: [
+      {
+        filePath: 'tsconfig.json:6',
+        message: 'forceConsistentCasingInFileNames rule should be enabled',
+      },
+    ],
+    name: 'plugin-tsconfig-force-consistent-casing',
+  },
+  {
+    expected: [
+      {
+        filePath: 'tsconfig.json:11',
+        message: 'strict mode should be enabled',
+      },
+    ],
+    name: 'plugin-tsconfig-strict',
+  },
+  {
+    expected: [
+      {
+        filePath: 'extension.json:1',
+        message: 'extensions with a main entry must configure contentSecurityPolicy',
+      },
+    ],
+    name: 'plugin-extension-json-content-security-policy',
+  },
+  {
+    expected: [
+      {
+        filePath: 'extension.json:4',
+        message: 'extension keybinding key is invalid',
+      },
+    ],
+    name: 'plugin-extension-json-valid-keybindings',
+  },
+  {
+    expected: [
+      {
+        filePath: '.devcontainer/devcontainer.json:2',
+        message: 'Unsupported devcontainer image: node:24',
+      },
+    ],
+    name: 'plugin-devcontainer-allowed-image',
+  },
+  {
+    expected: [
+      {
+        filePath: '.devcontainer/devcontainer.json:3',
+        message: 'desktop-lite devcontainer feature must be enabled',
+      },
+    ],
+    name: 'plugin-devcontainer-desktop-lite-feature',
+  },
+  {
+    expected: [
+      {
+        filePath: '.github/workflows/ci.yml:4',
+        message: 'Unsupported fail fast value: test',
+      },
+    ],
+    name: 'plugin-github-actions-fail-fast',
+  },
+  {
+    expected: [
+      {
+        filePath: '.github/workflows/ci.yml:7',
+        message: 'Unsupported github token value: 123',
+      },
+    ],
+    name: 'plugin-github-actions-github-token',
+  },
+  {
+    expected: [
+      {
+        filePath: '.github/workflows/ci.yml:4',
+        message: 'Unsupported max parallel value: test',
+      },
+    ],
+    name: 'plugin-github-actions-max-parallel',
+  },
+  {
+    expected: [
+      {
+        filePath: '.github/workflows/ci.yml:7',
+        message: 'Unsupported npm registry value: https://example.com',
+      },
+    ],
+    name: 'plugin-github-actions-npm-registry',
+  },
+  {
+    expected: [
+      {
+        filePath: '.github/workflows/ci.yml:7',
+        message: 'Unsupported node version file value: abc',
+      },
+    ],
+    name: 'plugin-github-actions-node-version-file',
+  },
+  {
+    expected: [
+      {
+        filePath: '.github/workflows/ci.yml:4',
+        message: 'Unsupported timeout minutes value: test',
+      },
+    ],
+    name: 'plugin-github-actions-timeout-minutes',
+  },
+  {
+    expected: [
+      {
+        filePath: 'src/main.ts:1',
+        message: 'Add an accessible name to this virtual-dom `Button` control.',
+      },
+    ],
+    name: 'plugin-virtual-dom-accessible-control-name',
+  },
+  {
+    expected: [
+      {
+        filePath: 'src/main.ts:3',
+        message: 'Add an explicit `role` to clickable virtual-dom div nodes.',
+      },
+    ],
+    name: 'plugin-virtual-dom-clickable-div-role',
+  },
+] as const
+
+test.each(cases)('$name', async ({ expected, name }) => {
+  expect(await runConfiguredFixture(name)).toEqual(expected)
+})
+
+test('plugin-github-actions-needs-reference', async () => {
+  const { expected, parsed } = await runFixture('invalid-needs-reference')
+  expect(parsed).toEqual(expected)
+})
+
+test('plugin-github-actions-working-directory', async () => {
+  const { expected, parsed } = await runFixture('invalid-working-directory')
+  expect(parsed).toEqual(expected)
+})

--- a/packages/e2e/test/util.ts
+++ b/packages/e2e/test/util.ts
@@ -50,3 +50,13 @@ export const runFixture = async (name: string): Promise<{ readonly expected: any
   const parsed = parseResult(fixturePath, resultJson)
   return { expected, parsed }
 }
+
+export const runConfiguredFixture = async (name: string): Promise<readonly any[]> => {
+  const fixturePath = join(root, 'packages', 'e2e', 'fixtures', name)
+  const eslintPath = join(root, 'node_modules', 'eslint', 'bin', 'eslint.js')
+  const { stdout } = await execa('node', [eslintPath, '.', '--format', 'json'], {
+    cwd: fixturePath,
+    reject: false,
+  })
+  return parseResult(fixturePath, JSON.parse(stdout))
+}


### PR DESCRIPTION
Adds 20 end-to-end cases covering first-party ESLint plugins and recommended configs across e2e, tsconfig, extension manifests, devcontainers, GitHub Actions, and virtual DOM.