### PR TITLE
feature: prevent renderer worker destructuring

### DIFF
--- a/packages/e2e/fixtures/sample-no-renderer-worker-destructuring/eslint.config.js
+++ b/packages/e2e/fixtures/sample-no-renderer-worker-destructuring/eslint.config.js
@@ -1,0 +1,3 @@
+import * as config from '../../../plugin/index.js'
+
+export default [...config.default]

--- a/packages/e2e/fixtures/sample-no-renderer-worker-destructuring/expected.json
+++ b/packages/e2e/fixtures/sample-no-renderer-worker-destructuring/expected.json
@@ -1,0 +1,6 @@
+[
+  {
+    "filePath": "src/main.ts:3",
+    "message": "Do not destructure `RendererWorker`; call its methods directly so they can be tree-shaken."
+  }
+]

--- a/packages/e2e/fixtures/sample-no-renderer-worker-destructuring/package.json
+++ b/packages/e2e/fixtures/sample-no-renderer-worker-destructuring/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "sample-no-renderer-worker-destructuring",
+  "version": "0.0.0-dev",
+  "license": "MIT",
+  "type": "module",
+  "main": "src/main.ts",
+  "scripts": {
+    "lint": "eslint .",
+    "lint:ci": "eslint . --format json --output-file result.json"
+  }
+}

--- a/packages/e2e/fixtures/sample-no-renderer-worker-destructuring/src/main.ts
+++ b/packages/e2e/fixtures/sample-no-renderer-worker-destructuring/src/main.ts
@@ -1,0 +1,7 @@
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+
+export const { invoke, set } = RendererWorker
+
+export const openUri = (uri: string): unknown => {
+  return RendererWorker.openUri(uri)
+}

--- a/packages/e2e/fixtures/sample-no-renderer-worker-destructuring/tsconfig.json
+++ b/packages/e2e/fixtures/sample-no-renderer-worker-destructuring/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ESNext",
+    "strict": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src"]
+}

--- a/packages/e2e/test/sample-no-renderer-worker-destructuring.test.ts
+++ b/packages/e2e/test/sample-no-renderer-worker-destructuring.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from '@jest/globals'
+import { runFixture } from './util.ts'
+
+test('sample-no-renderer-worker-destructuring', async () => {
+  const { expected, parsed } = await runFixture('sample-no-renderer-worker-destructuring')
+  expect(parsed).toEqual(expected)
+})

--- a/packages/plugin-rpc/src/index.ts
+++ b/packages/plugin-rpc/src/index.ts
@@ -1,4 +1,5 @@
 import type { Linter } from 'eslint'
+import * as noRendererWorkerDestructuring from './rules/no-renderer-worker-destructuring.ts'
 import * as preferUsingMockRpc from './rules/prefer-using-mock-rpc.ts'
 
 const plugin = {
@@ -8,6 +9,7 @@ const plugin = {
     version: '0.0.1',
   },
   rules: {
+    'no-renderer-worker-destructuring': noRendererWorkerDestructuring,
     'prefer-using-mock-rpc': preferUsingMockRpc,
   },
 }
@@ -19,6 +21,7 @@ const recommended: Linter.Config[] = [
       rpc: plugin,
     },
     rules: {
+      'rpc/no-renderer-worker-destructuring': 'error',
       'rpc/prefer-using-mock-rpc': 'error',
     },
   },

--- a/packages/plugin-rpc/src/rules/no-renderer-worker-destructuring.ts
+++ b/packages/plugin-rpc/src/rules/no-renderer-worker-destructuring.ts
@@ -1,0 +1,99 @@
+import type { Rule } from 'eslint'
+import type * as ESTree from 'estree'
+
+const rpcRegistryModule = '@lvce-editor/rpc-registry'
+const rendererWorkerName = 'RendererWorker'
+
+export const meta: Rule.RuleMetaData = {
+  docs: {
+    description: 'Disallow destructuring RendererWorker to preserve tree shaking',
+  },
+  messages: {
+    noRendererWorkerDestructuring: 'Do not destructure `RendererWorker`; call its methods directly so they can be tree-shaken.',
+  },
+  type: 'problem',
+}
+
+const findVariable = (scope: any, name: string): any => {
+  let currentScope = scope
+  while (currentScope) {
+    const variable = currentScope.set.get(name)
+    if (variable) {
+      return variable
+    }
+    currentScope = currentScope.upper
+  }
+  return undefined
+}
+
+const isImportFromRpcRegistry = (definition: any): boolean => {
+  return definition.type === 'ImportBinding' && definition.parent?.source?.value === rpcRegistryModule
+}
+
+const isRendererWorkerImport = (variable: any): boolean => {
+  return variable?.defs.some((definition: any) => {
+    if (!isImportFromRpcRegistry(definition) || definition.node?.type !== 'ImportSpecifier') {
+      return false
+    }
+    const { imported } = definition.node
+    return imported?.name === rendererWorkerName || imported?.value === rendererWorkerName
+  })
+}
+
+const isRpcRegistryNamespaceImport = (variable: any): boolean => {
+  return variable?.defs.some((definition: any) => {
+    return isImportFromRpcRegistry(definition) && definition.node?.type === 'ImportNamespaceSpecifier'
+  })
+}
+
+const unwrapExpression = (node: any): any => {
+  if (['ChainExpression', 'TSAsExpression', 'TSNonNullExpression', 'TSSatisfiesExpression', 'TSTypeAssertion'].includes(node?.type)) {
+    return unwrapExpression(node.expression)
+  }
+  return node
+}
+
+const isRendererWorkerProperty = (node: any): boolean => {
+  if (node.computed) {
+    return node.property?.type === 'Literal' && node.property.value === rendererWorkerName
+  }
+  return node.property?.type === 'Identifier' && node.property.name === rendererWorkerName
+}
+
+const isRendererWorkerExpression = (context: Rule.RuleContext, expression: any, node: ESTree.Node): boolean => {
+  const unwrappedExpression = unwrapExpression(expression)
+  const scope = context.sourceCode.getScope(node)
+  if (unwrappedExpression?.type === 'Identifier') {
+    return isRendererWorkerImport(findVariable(scope, unwrappedExpression.name))
+  }
+  if (
+    unwrappedExpression?.type !== 'MemberExpression' ||
+    unwrappedExpression.object?.type !== 'Identifier' ||
+    !isRendererWorkerProperty(unwrappedExpression)
+  ) {
+    return false
+  }
+  return isRpcRegistryNamespaceImport(findVariable(scope, unwrappedExpression.object.name))
+}
+
+const reportObjectPattern = (context: Rule.RuleContext, pattern: ESTree.ObjectPattern): void => {
+  context.report({
+    messageId: 'noRendererWorkerDestructuring',
+    node: pattern,
+  })
+}
+
+export const create = (context: Rule.RuleContext): Rule.RuleListener => {
+  return {
+    AssignmentExpression(node: ESTree.AssignmentExpression): void {
+      if (node.left.type === 'ObjectPattern' && isRendererWorkerExpression(context, node.right, node)) {
+        reportObjectPattern(context, node.left)
+      }
+    },
+    VariableDeclarator(node: ESTree.VariableDeclarator): void {
+      if (node.id.type === 'ObjectPattern' && isRendererWorkerExpression(context, node.init, node)) {
+        reportObjectPattern(context, node.id)
+      }
+    },
+  }
+}

--- a/packages/plugin-rpc/test/index.ts
+++ b/packages/plugin-rpc/test/index.ts
@@ -1,1 +1,2 @@
+import './no-renderer-worker-destructuring.test.ts'
 import './prefer-using-mock-rpc.test.ts'

--- a/packages/plugin-rpc/test/no-renderer-worker-destructuring.test.ts
+++ b/packages/plugin-rpc/test/no-renderer-worker-destructuring.test.ts
@@ -1,0 +1,108 @@
+import { RuleTester } from 'eslint'
+import * as rule from '../src/rules/no-renderer-worker-destructuring.ts'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+})
+
+ruleTester.run('no-renderer-worker-destructuring', rule, {
+  invalid: [
+    {
+      code: `
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+
+export const { getActiveEditorId, set } = RendererWorker
+`,
+      errors: [
+        {
+          column: 14,
+          endColumn: 40,
+          endLine: 4,
+          line: 4,
+          messageId: 'noRendererWorkerDestructuring',
+        },
+      ],
+    },
+    {
+      code: `
+import { RendererWorker as Worker } from '@lvce-editor/rpc-registry'
+
+const { set } = Worker
+`,
+      errors: [
+        {
+          messageId: 'noRendererWorkerDestructuring',
+        },
+      ],
+    },
+    {
+      code: `
+import * as RpcRegistry from '@lvce-editor/rpc-registry'
+
+const { set } = RpcRegistry.RendererWorker
+`,
+      errors: [
+        {
+          messageId: 'noRendererWorkerDestructuring',
+        },
+      ],
+    },
+    {
+      code: `
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+
+let set
+;({ set } = RendererWorker)
+`,
+      errors: [
+        {
+          messageId: 'noRendererWorkerDestructuring',
+        },
+      ],
+    },
+  ],
+  valid: [
+    {
+      code: `
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+
+export const set = RendererWorker.set
+`,
+    },
+    {
+      code: `
+const RendererWorker = createRendererWorker()
+const { set } = RendererWorker
+`,
+    },
+    {
+      code: `
+import { RendererWorker } from 'other-package'
+
+const { set } = RendererWorker
+`,
+    },
+    {
+      code: `
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+
+const readSet = (RendererWorker) => {
+  const { set } = RendererWorker
+  return set
+}
+
+RendererWorker.set()
+`,
+    },
+    {
+      code: `
+import { EditorWorker } from '@lvce-editor/rpc-registry'
+
+const { set } = EditorWorker
+`,
+    },
+  ],
+})


### PR DESCRIPTION
Adds an RPC ESLint rule that rejects destructuring RendererWorker imports so calls remain tree-shakeable.

Includes import-aware unit coverage and an end-to-end shared-config fixture.