### PR TITLE
fix: publish eslint config plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,10 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
       - run: npm publish --access public
+        working-directory: ./.tmp/plugin-eslint-config
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - run: npm publish --access public
         working-directory: ./.tmp/plugin-github-actions
       - run: npm publish --access public
         working-directory: ./.tmp/plugin-tsconfig


### PR DESCRIPTION
Publish the new @lvce-editor/eslint-plugin-eslint-config package from the release workflow alongside the other built ESLint plugins.