### PR TITLE
feature: disallow skip zero exports

### DIFF
--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -4,6 +4,7 @@ import * as noImports from './rules/no-imports.ts'
 import * as noInlineLocatorInExpect from './rules/no-inline-locator-in-expect.ts'
 import * as noInlineNthInExpect from './rules/no-inline-nth-in-expect.ts'
 import * as noLazyNthVariableName from './rules/no-lazy-nth-variable-name.ts'
+import * as noSkipZero from './rules/no-skip-zero.ts'
 import * as preferDirectApiDestructuring from './rules/prefer-direct-api-destructuring.ts'
 import * as preferExecuteExtensionCommand from './rules/prefer-execute-extension-command.ts'
 import * as preferFileSystemSetFiles from './rules/prefer-filesystem-set-files.ts'
@@ -22,6 +23,7 @@ const plugin = {
     'no-inline-locator-in-expect': noInlineLocatorInExpect,
     'no-inline-nth-in-expect': noInlineNthInExpect,
     'no-lazy-nth-variable-name': noLazyNthVariableName,
+    'no-skip-zero': noSkipZero,
     'prefer-direct-api-destructuring': preferDirectApiDestructuring,
     'prefer-execute-extension-command': preferExecuteExtensionCommand,
     'prefer-filesystem-set-files': preferFileSystemSetFiles,
@@ -42,6 +44,7 @@ const recommended: Linter.Config[] = [
       'e2e/no-inline-locator-in-expect': 'error',
       'e2e/no-inline-nth-in-expect': 'error',
       'e2e/no-lazy-nth-variable-name': 'error',
+      'e2e/no-skip-zero': 'error',
       'e2e/prefer-direct-api-destructuring': 'error',
       'e2e/prefer-execute-extension-command': 'error',
       'e2e/prefer-filesystem-set-files': 'error',

--- a/packages/plugin-e2e/src/rules/no-skip-zero.ts
+++ b/packages/plugin-e2e/src/rules/no-skip-zero.ts
@@ -1,0 +1,50 @@
+import type { Rule } from 'eslint'
+import type * as ESTree from 'estree'
+
+export const meta: Rule.RuleMetaData = {
+  docs: {
+    description: 'Disallow exporting skip with a value of zero',
+  },
+  fixable: 'code',
+  messages: {
+    noSkipZero: 'Omit the skip export when the test should run.',
+  },
+  type: 'suggestion',
+}
+
+const isSkipZeroDeclaration = (node: ESTree.ExportNamedDeclaration): boolean => {
+  const { declaration } = node
+  if (declaration?.type !== 'VariableDeclaration' || declaration.kind !== 'const' || declaration.declarations.length !== 1) {
+    return false
+  }
+  const [{ id, init }] = declaration.declarations
+  return id.type === 'Identifier' && id.name === 'skip' && init?.type === 'Literal' && init.value === 0
+}
+
+const getRemovalRange = (node: ESTree.ExportNamedDeclaration, sourceCode: Rule.RuleContext['sourceCode']): [number, number] | undefined => {
+  if (!node.range) {
+    return undefined
+  }
+  const trailingLineBreaks = /^(?:[\t ]*\r?\n)+/.exec(sourceCode.text.slice(node.range[1]))?.[0].length ?? 0
+  return [node.range[0], node.range[1] + trailingLineBreaks]
+}
+
+export const create = (context: Rule.RuleContext): Rule.RuleListener => {
+  const { sourceCode } = context
+
+  return {
+    ExportNamedDeclaration(node: ESTree.ExportNamedDeclaration): void {
+      if (!isSkipZeroDeclaration(node)) {
+        return
+      }
+      context.report({
+        fix(fixer) {
+          const range = getRemovalRange(node, sourceCode)
+          return range ? fixer.removeRange(range) : fixer.remove(node)
+        },
+        messageId: 'noSkipZero',
+        node,
+      })
+    },
+  }
+}

--- a/packages/plugin-e2e/test/index.ts
+++ b/packages/plugin-e2e/test/index.ts
@@ -1,6 +1,7 @@
 import './no-direct-click.test.ts'
 import './no-imports.test.ts'
 import './no-lazy-nth-variable-name.test.ts'
+import './no-skip-zero.test.ts'
 import './no-inline-locator-in-expect.test.ts'
 import './no-inline-nth-in-expect.test.ts'
 import './prefer-direct-api-destructuring.test.ts'

--- a/packages/plugin-e2e/test/no-skip-zero.test.ts
+++ b/packages/plugin-e2e/test/no-skip-zero.test.ts
@@ -1,0 +1,49 @@
+import { RuleTester } from 'eslint'
+import * as rule from '../src/rules/no-skip-zero.ts'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+  },
+})
+
+ruleTester.run('no-skip-zero', rule, {
+  invalid: [
+    {
+      code: `
+import { Test } from '@lvce-editor/test-with-playwright'
+
+export const skip = 0
+
+export const test = async () => Test
+`,
+      errors: [{ messageId: 'noSkipZero' }],
+      output: `
+import { Test } from '@lvce-editor/test-with-playwright'
+
+export const test = async () => Test
+`,
+    },
+    {
+      code: `export const skip = 0
+export const test = async () => {}`,
+      errors: [{ messageId: 'noSkipZero' }],
+      output: `export const test = async () => {}`,
+    },
+  ],
+  valid: [
+    {
+      code: `export const skip = true`,
+    },
+    {
+      code: `export const skip = 1`,
+    },
+    {
+      code: `const skip = 0`,
+    },
+    {
+      code: `export const skipped = 0`,
+    },
+  ],
+})


### PR DESCRIPTION
Adds the recommended e2e/no-skip-zero rule. The autofix removes redundant zero-valued skip exports while preserving skip=true and skip=1.