### PR TITLE
feature: allow test worker type imports in e2e tests

### DIFF
--- a/packages/e2e/fixtures/sample-e2e-no-imports/expected.json
+++ b/packages/e2e/fixtures/sample-e2e-no-imports/expected.json
@@ -1,6 +1,6 @@
 [
   {
     "filePath": "e2e/main.ts:2",
-    "message": "E2E tests must be self-contained. Only type imports from @lvce-editor/test-with-playwright are allowed."
+    "message": "E2E tests must be self-contained. Only type imports from @lvce-editor/test-with-playwright and @lvce-editor/test-worker are allowed."
   }
 ]

--- a/packages/plugin-e2e/src/rules/no-imports.ts
+++ b/packages/plugin-e2e/src/rules/no-imports.ts
@@ -1,7 +1,7 @@
 import type { Rule } from 'eslint'
 import type * as ESTree from 'estree'
 
-const allowedTypeImportSource = '@lvce-editor/test-with-playwright'
+const allowedTypeImportSources = new Set(['@lvce-editor/test-with-playwright', '@lvce-editor/test-worker'])
 
 interface ImportDeclaration extends ESTree.BaseNode {
   readonly importKind?: 'type' | 'value'
@@ -16,16 +16,16 @@ interface ImportSpecifier extends ESTree.BaseNode {
 
 export const meta: Rule.RuleMetaData = {
   docs: {
-    description: 'Disallow imports in e2e tests except type imports from @lvce-editor/test-with-playwright',
+    description: 'Disallow imports in e2e tests except type imports from the test runner and test worker',
   },
   messages: {
-    noImports: 'E2E tests must be self-contained. Only type imports from @lvce-editor/test-with-playwright are allowed.',
+    noImports: 'E2E tests must be self-contained. Only type imports from @lvce-editor/test-with-playwright and @lvce-editor/test-worker are allowed.',
   },
   type: 'problem',
 }
 
 const isAllowedTypeImport = (node: ImportDeclaration): boolean => {
-  if (node.source.value !== allowedTypeImportSource) {
+  if (typeof node.source.value !== 'string' || !allowedTypeImportSources.has(node.source.value)) {
     return false
   }
   if (node.importKind === 'type') {

--- a/packages/plugin-e2e/test/no-imports.test.ts
+++ b/packages/plugin-e2e/test/no-imports.test.ts
@@ -32,6 +32,10 @@ ruleTester.run('no-imports', rule, {
       code: `import '@lvce-editor/test-with-playwright'`,
       errors: [{ messageId: 'noImports' }],
     },
+    {
+      code: `import { Test } from '@lvce-editor/test-worker'`,
+      errors: [{ messageId: 'noImports' }],
+    },
   ],
   valid: [
     {
@@ -45,6 +49,12 @@ ruleTester.run('no-imports', rule, {
     },
     {
       code: `import type * as PlaywrightTypes from '@lvce-editor/test-with-playwright'`,
+    },
+    {
+      code: `import type { Test } from '@lvce-editor/test-worker'`,
+    },
+    {
+      code: `import { type Test } from '@lvce-editor/test-worker'`,
     },
   ],
 })


### PR DESCRIPTION
Allow e2e tests to import page-object API types directly from `@lvce-editor/test-worker`.

Runtime imports and type imports from all other packages remain disallowed.

Tests cover accepted type-only syntax and rejected runtime imports.