### PR TITLE
feature: disallow inline uri resolution in e2e tests

### DIFF
--- a/packages/e2e/fixtures/sample-e2e-no-inline-import-meta-resolve-in-open-uri/e2e/main.ts
+++ b/packages/e2e/fixtures/sample-e2e-no-inline-import-meta-resolve-in-open-uri/e2e/main.ts
@@ -1,0 +1,7 @@
+const Main = {
+  async openUri(_uri: string): Promise<void> {},
+}
+
+export const test = async (): Promise<void> => {
+  await Main.openUri(import.meta.resolve('../sample-files/file.txt'))
+}

--- a/packages/e2e/fixtures/sample-e2e-no-inline-import-meta-resolve-in-open-uri/eslint.config.js
+++ b/packages/e2e/fixtures/sample-e2e-no-inline-import-meta-resolve-in-open-uri/eslint.config.js
@@ -1,0 +1,4 @@
+import * as config from '../../../plugin/index.js'
+import { defineConfig } from 'eslint/config'
+
+export default defineConfig(config.default)

--- a/packages/e2e/fixtures/sample-e2e-no-inline-import-meta-resolve-in-open-uri/expected.json
+++ b/packages/e2e/fixtures/sample-e2e-no-inline-import-meta-resolve-in-open-uri/expected.json
@@ -1,0 +1,6 @@
+[
+  {
+    "filePath": "e2e/main.ts:6",
+    "message": "Assign import.meta.resolve(...) to a variable before passing the URI to Main.openUri(...)."
+  }
+]

--- a/packages/e2e/fixtures/sample-e2e-no-inline-import-meta-resolve-in-open-uri/package.json
+++ b/packages/e2e/fixtures/sample-e2e-no-inline-import-meta-resolve-in-open-uri/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "sample-e2e-no-inline-import-meta-resolve-in-open-uri",
+  "version": "0.0.0-dev",
+  "license": "MIT",
+  "type": "module",
+  "main": "e2e/main.ts",
+  "scripts": {
+    "lint": "eslint .",
+    "lint:ci": "eslint . --format json --output-file result.json"
+  }
+}

--- a/packages/e2e/fixtures/sample-e2e-no-inline-import-meta-resolve-in-open-uri/tsconfig.json
+++ b/packages/e2e/fixtures/sample-e2e-no-inline-import-meta-resolve-in-open-uri/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "checkJs": true,
+    "target": "esnext",
+    "types": ["node"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "assumeChangesOnlyAffectDirectDependencies": true,
+    "strict": true,
+    "noImplicitAny": false,
+    "composite": true,
+    "allowImportingTsExtensions": true,
+    "rootDir": "."
+  },
+  "include": ["e2e"]
+}

--- a/packages/e2e/test/sample-e2e-no-inline-import-meta-resolve-in-open-uri.test.ts
+++ b/packages/e2e/test/sample-e2e-no-inline-import-meta-resolve-in-open-uri.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from '@jest/globals'
+import { runFixture } from './util.ts'
+
+test('sample-e2e-no-inline-import-meta-resolve-in-open-uri', async () => {
+  const { expected, parsed } = await runFixture('sample-e2e-no-inline-import-meta-resolve-in-open-uri')
+  expect(parsed).toEqual(expected)
+})

--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -1,6 +1,7 @@
 import type { Linter } from 'eslint'
 import * as noDirectClick from './rules/no-direct-click.ts'
 import * as noImports from './rules/no-imports.ts'
+import * as noInlineImportMetaResolveInOpenUri from './rules/no-inline-import-meta-resolve-in-open-uri.ts'
 import * as noInlineLocatorInExpect from './rules/no-inline-locator-in-expect.ts'
 import * as noInlineNthInExpect from './rules/no-inline-nth-in-expect.ts'
 import * as noLazyNthVariableName from './rules/no-lazy-nth-variable-name.ts'
@@ -20,6 +21,7 @@ const plugin = {
   rules: {
     'no-direct-click': noDirectClick,
     'no-imports': noImports,
+    'no-inline-import-meta-resolve-in-open-uri': noInlineImportMetaResolveInOpenUri,
     'no-inline-locator-in-expect': noInlineLocatorInExpect,
     'no-inline-nth-in-expect': noInlineNthInExpect,
     'no-lazy-nth-variable-name': noLazyNthVariableName,
@@ -41,6 +43,7 @@ const recommended: Linter.Config[] = [
     rules: {
       'e2e/no-direct-click': 'error',
       'e2e/no-imports': 'error',
+      'e2e/no-inline-import-meta-resolve-in-open-uri': 'error',
       'e2e/no-inline-locator-in-expect': 'error',
       'e2e/no-inline-nth-in-expect': 'error',
       'e2e/no-lazy-nth-variable-name': 'error',

--- a/packages/plugin-e2e/src/rules/no-inline-import-meta-resolve-in-open-uri.ts
+++ b/packages/plugin-e2e/src/rules/no-inline-import-meta-resolve-in-open-uri.ts
@@ -1,0 +1,54 @@
+import type { Rule } from 'eslint'
+import type * as ESTree from 'estree'
+
+export const meta: Rule.RuleMetaData = {
+  docs: {
+    description: 'Disallow inline import.meta.resolve calls in Main.openUri calls',
+  },
+  messages: {
+    noInlineImportMetaResolveInOpenUri: 'Assign import.meta.resolve(...) to a variable before passing the URI to Main.openUri(...).',
+  },
+  type: 'problem',
+}
+
+const isIdentifier = (node: ESTree.Node, name: string): node is ESTree.Identifier => {
+  return node.type === 'Identifier' && node.name === name
+}
+
+const isImportMeta = (node: ESTree.Node): node is ESTree.MetaProperty => {
+  return node.type === 'MetaProperty' && isIdentifier(node.meta, 'import') && isIdentifier(node.property, 'meta')
+}
+
+const isImportMetaResolveCall = (node: ESTree.Expression | ESTree.SpreadElement): boolean => {
+  return (
+    node.type === 'CallExpression' &&
+    node.callee.type === 'MemberExpression' &&
+    !node.callee.computed &&
+    isImportMeta(node.callee.object) &&
+    isIdentifier(node.callee.property, 'resolve')
+  )
+}
+
+const isMainOpenUriCall = (node: ESTree.SimpleCallExpression): boolean => {
+  return (
+    node.callee.type === 'MemberExpression' &&
+    !node.callee.computed &&
+    isIdentifier(node.callee.object, 'Main') &&
+    isIdentifier(node.callee.property, 'openUri')
+  )
+}
+
+export const create = (context: Rule.RuleContext): Rule.RuleListener => {
+  return {
+    CallExpression(node: ESTree.SimpleCallExpression): void {
+      const [uri] = node.arguments
+      if (!isMainOpenUriCall(node) || !uri || !isImportMetaResolveCall(uri)) {
+        return
+      }
+      context.report({
+        messageId: 'noInlineImportMetaResolveInOpenUri',
+        node: uri,
+      })
+    },
+  }
+}

--- a/packages/plugin-e2e/test/index.ts
+++ b/packages/plugin-e2e/test/index.ts
@@ -1,5 +1,6 @@
 import './no-direct-click.test.ts'
 import './no-imports.test.ts'
+import './no-inline-import-meta-resolve-in-open-uri.test.ts'
 import './no-lazy-nth-variable-name.test.ts'
 import './no-skip-zero.test.ts'
 import './no-inline-locator-in-expect.test.ts'

--- a/packages/plugin-e2e/test/no-inline-import-meta-resolve-in-open-uri.test.ts
+++ b/packages/plugin-e2e/test/no-inline-import-meta-resolve-in-open-uri.test.ts
@@ -1,0 +1,46 @@
+import { RuleTester } from 'eslint'
+import * as rule from '../src/rules/no-inline-import-meta-resolve-in-open-uri.ts'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+  },
+})
+
+ruleTester.run('no-inline-import-meta-resolve-in-open-uri', rule, {
+  invalid: [
+    {
+      code: `
+export const test = async ({ Main }) => {
+  await Main.openUri(import.meta.resolve('../sample-files/file.txt'))
+}
+`,
+      errors: [{ messageId: 'noInlineImportMetaResolveInOpenUri' }],
+    },
+  ],
+  valid: [
+    {
+      code: `
+export const test = async ({ Main }) => {
+  const uri = import.meta.resolve('../sample-files/file.txt')
+  await Main.openUri(uri)
+}
+`,
+    },
+    {
+      code: `
+export const test = async ({ Main }) => {
+  await Main.openUri(resolveUri('../sample-files/file.txt'))
+}
+`,
+    },
+    {
+      code: `
+export const test = async () => {
+  await Other.openUri(import.meta.resolve('../sample-files/file.txt'))
+}
+`,
+    },
+  ],
+})


### PR DESCRIPTION
Adds the recommended `e2e/no-inline-import-meta-resolve-in-open-uri` rule so `import.meta.resolve(...)` is assigned to a URI variable before calling `Main.openUri(...)`.

Includes rule-level and integration coverage.