### PR TITLE
feature: disallow manual memory clipboard cleanup

### DIFF
--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -1,5 +1,6 @@
 import type { Linter } from 'eslint'
 import * as noDirectClick from './rules/no-direct-click.ts'
+import * as noDisableMemoryClipBoardInFinally from './rules/no-disable-memory-clipboard-in-finally.ts'
 import * as noImports from './rules/no-imports.ts'
 import * as noInlineLocatorInExpect from './rules/no-inline-locator-in-expect.ts'
 import * as noInlineNthInExpect from './rules/no-inline-nth-in-expect.ts'
@@ -19,6 +20,7 @@ const plugin = {
   },
   rules: {
     'no-direct-click': noDirectClick,
+    'no-disable-memory-clipboard-in-finally': noDisableMemoryClipBoardInFinally,
     'no-imports': noImports,
     'no-inline-locator-in-expect': noInlineLocatorInExpect,
     'no-inline-nth-in-expect': noInlineNthInExpect,
@@ -40,6 +42,7 @@ const recommended: Linter.Config[] = [
     },
     rules: {
       'e2e/no-direct-click': 'error',
+      'e2e/no-disable-memory-clipboard-in-finally': 'error',
       'e2e/no-imports': 'error',
       'e2e/no-inline-locator-in-expect': 'error',
       'e2e/no-inline-nth-in-expect': 'error',

--- a/packages/plugin-e2e/src/rules/no-disable-memory-clipboard-in-finally.ts
+++ b/packages/plugin-e2e/src/rules/no-disable-memory-clipboard-in-finally.ts
@@ -1,0 +1,49 @@
+import type { Rule } from 'eslint'
+import type * as ESTree from 'estree'
+
+export const meta: Rule.RuleMetaData = {
+  docs: {
+    description: 'Disallow disabling the memory clipboard in finally blocks',
+  },
+  messages: {
+    noDisableMemoryClipBoardInFinally:
+      'Do not call ClipBoard.disableMemoryClipBoard() in a finally block. The memory clipboard is disabled automatically after each test.',
+  },
+  type: 'problem',
+}
+
+const isDisableMemoryClipBoardCall = (node: ESTree.SimpleCallExpression): boolean => {
+  const { callee } = node
+  return (
+    callee.type === 'MemberExpression' &&
+    callee.object.type === 'Identifier' &&
+    callee.object.name === 'ClipBoard' &&
+    callee.property.type === 'Identifier' &&
+    callee.property.name === 'disableMemoryClipBoard'
+  )
+}
+
+const isInFinallyBlock = (context: Rule.RuleContext, node: ESTree.SimpleCallExpression): boolean => {
+  const ancestors = context.sourceCode.getAncestors(node)
+  return ancestors.some((ancestor) => {
+    if (ancestor.type !== 'TryStatement') {
+      return false
+    }
+    const { finalizer } = ancestor
+    return finalizer !== null && finalizer !== undefined && ancestors.includes(finalizer)
+  })
+}
+
+export const create = (context: Rule.RuleContext): Rule.RuleListener => {
+  return {
+    CallExpression(node: ESTree.SimpleCallExpression): void {
+      if (!isDisableMemoryClipBoardCall(node) || !isInFinallyBlock(context, node)) {
+        return
+      }
+      context.report({
+        messageId: 'noDisableMemoryClipBoardInFinally',
+        node,
+      })
+    },
+  }
+}

--- a/packages/plugin-e2e/test/index.ts
+++ b/packages/plugin-e2e/test/index.ts
@@ -1,4 +1,5 @@
 import './no-direct-click.test.ts'
+import './no-disable-memory-clipboard-in-finally.test.ts'
 import './no-imports.test.ts'
 import './no-lazy-nth-variable-name.test.ts'
 import './no-skip-zero.test.ts'

--- a/packages/plugin-e2e/test/no-disable-memory-clipboard-in-finally.test.ts
+++ b/packages/plugin-e2e/test/no-disable-memory-clipboard-in-finally.test.ts
@@ -1,0 +1,80 @@
+import { RuleTester } from 'eslint'
+import * as rule from '../src/rules/no-disable-memory-clipboard-in-finally.ts'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+  },
+})
+
+ruleTester.run('no-disable-memory-clipboard-in-finally', rule, {
+  invalid: [
+    {
+      code: `
+export const test = async ({ ClipBoard }) => {
+  await ClipBoard.enableMemoryClipBoard()
+  try {
+    await ClipBoard.shouldHaveText('hello')
+  } finally {
+    await ClipBoard.disableMemoryClipBoard()
+  }
+}
+`,
+      errors: [{ messageId: 'noDisableMemoryClipBoardInFinally' }],
+    },
+    {
+      code: `
+export const test = async ({ ClipBoard }) => {
+  try {
+    await runTest()
+  } finally {
+    if (cleanup) {
+      await ClipBoard.disableMemoryClipBoard()
+    }
+  }
+}
+`,
+      errors: [{ messageId: 'noDisableMemoryClipBoardInFinally' }],
+    },
+  ],
+  valid: [
+    {
+      code: `
+export const test = async ({ ClipBoard }) => {
+  await ClipBoard.enableMemoryClipBoard()
+  await ClipBoard.shouldHaveText('hello')
+}
+`,
+    },
+    {
+      code: `
+export const test = async ({ ClipBoard }) => {
+  await ClipBoard.disableMemoryClipBoard()
+}
+`,
+    },
+    {
+      code: `
+export const test = async ({ ClipBoard }) => {
+  try {
+    await runTest()
+  } finally {
+    await ClipBoard.clear()
+  }
+}
+`,
+    },
+    {
+      code: `
+export const test = async ({ clipboard }) => {
+  try {
+    await runTest()
+  } finally {
+    await clipboard.disableMemoryClipBoard()
+  }
+}
+`,
+    },
+  ],
+})


### PR DESCRIPTION
Adds a recommended E2E lint rule that rejects ClipBoard.disableMemoryClipBoard() inside finally blocks now that the test worker performs automatic cleanup.